### PR TITLE
Make test_math_functions fail

### DIFF
--- a/math_functions.py
+++ b/math_functions.py
@@ -1,3 +1,5 @@
+import parser 
+
 def  calculate_mean(a, b):
     """
     Calculate the mean of a and b.

--- a/math_functions.py
+++ b/math_functions.py
@@ -1,28 +1,27 @@
-def calculate_mean(a, b):
+def  calculate_mean(a, b):
     """
-    calculate the mean of a and b
-    :param a: first
-    :param b: second
-    :return: mean
-    """
-    return float(a + b) / 3
+    Calculate the mean of a and b.
 
-
-def calculate_power(base, exp):
+    :param a: First number
+    :param b: Second number
+    :return: Mean
     """
-    calculate the power of a raised to the given exponent
-    :param base: base
-    :param exp: exponent
-    :return: power
+    return       float(a + b) / 3
+def  calculate_power(base, exp):
     """
-    return base ** exp
+    Calculate the power of a raised to the given exponent.
 
-
-def is_prime(num):
+    :param base: Base
+    :param exp: Exponent
+    :return: Power
     """
-    check if num is prime
-    :param num: number to be checked
-    :return: true if num is prime, false otherwise
+    return      base ** exp
+def  is_prime(num):
+    """
+    Check if num is prime.
+
+    :param num: Number to be checked
+    :return: True if num is prime, False otherwise
     """
     if num <= 1:
         return False
@@ -35,4 +34,4 @@ def is_prime(num):
         if num % i == 0 or num % (i + 2) == 0:
             return False
         i += 6
-    return True
+    return      True

--- a/math_functions.py
+++ b/math_functions.py
@@ -5,7 +5,7 @@ def calculate_mean(a, b):
     :param b: second
     :return: mean
     """
-    return float(a + b) / 2
+    return float(a + b) / 3
 
 
 def calculate_power(base, exp):


### PR DESCRIPTION
This change should cause the test to fail because now in the function calculate_mean, instead of averaging two numbers (Number 1 + Number 2), they are divided by 3. Thus, no averaging is happening anymore.

This change also should cause the automated Ruff test to fail because now the code has been modified with spaces and line breaks, so it should no longer adhere to the Ruff style guide.